### PR TITLE
update to rusty_paseto 0.7

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,14 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features v3 --tests
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-default-features --features v4 --tests
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -91,15 +91,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95c2fcf79ad1932ac6269a738109997a83c227c09b75842ae564dc8ede6a861c"
 dependencies = [
  "base64ct",
- "blake2 0.10.6",
+ "blake2",
  "password-hash",
 ]
-
-[[package]]
-name = "base16ct"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -109,9 +103,9 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -139,22 +133,11 @@ dependencies = [
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -167,33 +150,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chacha20"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
-dependencies = [
- "cfg-if",
- "cipher 0.3.0",
- "cpufeatures",
-]
 
 [[package]]
 name = "chacha20"
@@ -290,18 +256,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
-dependencies = [
- "generic-array",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
@@ -320,16 +274,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -359,7 +303,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest",
  "fiat-crypto",
  "platforms",
  "rustc_version",
@@ -380,23 +324,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
-dependencies = [
- "const-oid",
- "pem-rfc7468 0.6.0",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56acb310e15652100da43d130af8d97b509e95af61aab1c5a7939ef24337ee17"
 dependencies = [
  "const-oid",
- "pem-rfc7468 0.7.0",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -413,15 +346,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
@@ -434,28 +358,16 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
-dependencies = [
- "der 0.6.1",
- "elliptic-curve 0.12.3",
- "rfc6979 0.3.1",
- "signature 1.6.4",
-]
-
-[[package]]
-name = "ecdsa"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
- "der 0.7.6",
- "digest 0.10.7",
- "elliptic-curve 0.13.5",
- "rfc6979 0.4.0",
- "signature 2.1.0",
- "spki 0.7.2",
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -464,8 +376,8 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fb04eee5d9d907f29e80ee6b0e78f7e2c82342c63e3580d8c4f69d9d5aad963"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.1.0",
+ "pkcs8",
+ "signature",
 ]
 
 [[package]]
@@ -483,43 +395,21 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
-dependencies = [
- "base16ct 0.1.1",
- "crypto-bigint 0.4.9",
- "der 0.6.1",
- "digest 0.10.7",
- "ff 0.12.1",
- "generic-array",
- "group 0.12.1",
- "hkdf",
- "pem-rfc7468 0.6.0",
- "pkcs8 0.9.0",
- "rand_core",
- "sec1 0.3.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.2",
- "digest 0.10.7",
- "ff 0.13.0",
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "hkdf",
- "pem-rfc7468 0.7.0",
- "pkcs8 0.10.2",
+ "pem-rfc7468",
+ "pkcs8",
  "rand_core",
- "sec1 0.7.2",
+ "sec1",
  "subtle",
  "zeroize",
 ]
@@ -532,7 +422,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -546,13 +436,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.12.1"
+name = "escape8259"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "ba4f4911e3666fcd7826997b4745c8224295a6f3072f1418c3067b97a67557ee"
 dependencies = [
- "rand_core",
- "subtle",
+ "rustversion",
 ]
 
 [[package]]
@@ -602,22 +491,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -664,7 +542,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -684,7 +562,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -696,14 +574,14 @@ dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "iso8601"
-version = "0.4.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b94fbeb759754d87e1daea745bc8efd3037cd16980331fe1d1524c9a79ce96"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
@@ -715,27 +593,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.146"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libtest-mimic"
-version = "0.6.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8de370f98a6cb8a4606618e53e802f93b094ddec0f96988eaec2c27e6e9ce7"
+checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
 dependencies = [
  "clap",
+ "escape8259",
  "termcolor",
  "threadpool",
 ]
@@ -745,12 +615,6 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "log"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -798,23 +662,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "p384"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc8c5bf642dde52bb9e87c0ecd8ca5a76faac2eeed98dedb7c717997e1080aa"
-dependencies = [
- "ecdsa 0.14.8",
- "elliptic-curve 0.12.3",
- "sha2",
-]
-
-[[package]]
-name = "p384"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70786f51bcc69f6a4c0360e063a4cac5419ef7c5cd5b3c99ad70f3be5ba79209"
 dependencies = [
- "ecdsa 0.16.7",
- "elliptic-curve 0.13.5",
+ "ecdsa",
+ "elliptic-curve",
  "primeorder",
  "sha2",
 ]
@@ -836,17 +689,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -860,22 +704,12 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
-dependencies = [
- "der 0.6.1",
- "spki 0.6.0",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.6",
- "spki 0.7.2",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -896,7 +730,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2fcef82c0ec6eefcc179b978446c399b3cdf73c392c35604e399eee6df1ee3"
 dependencies = [
- "elliptic-curve 0.13.5",
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -955,17 +789,6 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
-dependencies = [
- "crypto-bigint 0.4.9",
- "hmac",
- "zeroize",
-]
-
-[[package]]
-name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
@@ -976,17 +799,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
+ "cfg-if",
+ "getrandom",
  "libc",
- "once_cell",
  "spin",
  "untrusted",
- "web-sys",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1009,31 +832,37 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "rusty_paserk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aes 0.8.3",
  "arbitrary",
  "argon2",
  "base64",
  "base64ct",
- "blake2 0.10.6",
- "chacha20 0.9.1",
+ "blake2",
+ "chacha20",
  "cipher 0.4.4",
  "ctr 0.9.2",
  "curve25519-dalek",
- "digest 0.10.7",
+ "digest",
  "ed25519-dalek",
- "ff 0.13.0",
+ "ff",
  "generic-array",
  "hex",
  "hmac",
  "libtest-mimic",
- "p384 0.13.0",
+ "p384",
  "pbkdf2",
  "rand",
  "rusty_paseto",
@@ -1045,19 +874,21 @@ dependencies = [
 
 [[package]]
 name = "rusty_paseto"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdf6eecf99ba1cc36c0629fc69772bbd7fbec0d6a84a29076c25dc0f587be16"
+checksum = "b03abd0624688047cc65eadc5588dd35be44151ce7b6e7e7dea4976f5b3dcd54"
 dependencies = [
  "aes 0.7.5",
  "base64",
- "blake2 0.9.2",
- "chacha20 0.8.2",
+ "blake2",
+ "chacha20",
+ "digest",
  "ed25519-dalek",
  "hex",
  "hmac",
  "iso8601",
- "p384 0.11.2",
+ "p384",
+ "rand_core",
  "ring",
  "sha2",
  "thiserror",
@@ -1073,28 +904,14 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "sec1"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
-dependencies = [
- "base16ct 0.1.1",
- "der 0.6.1",
- "generic-array",
- "pkcs8 0.9.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.6",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
+ "pkcs8",
  "subtle",
  "zeroize",
 ]
@@ -1144,17 +961,7 @@ checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
-dependencies = [
- "digest 0.10.7",
- "rand_core",
+ "digest",
 ]
 
 [[package]]
@@ -1163,25 +970,15 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spki"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
-dependencies = [
- "base64ct",
- "der 0.6.1",
-]
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -1190,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
 dependencies = [
  "base64ct",
- "der 0.7.6",
+ "der",
 ]
 
 [[package]]
@@ -1301,9 +1098,9 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -1322,70 +1119,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"
@@ -1424,7 +1157,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -1433,13 +1175,29 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -1449,10 +1207,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1461,10 +1231,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1473,16 +1261,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty_paserk"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Conrad Ludgate <conradludgate@gmail.com>"]
 repository = "https://github.com/conradludgate/rusty-paserk"
@@ -16,7 +16,7 @@ categories = [
 ]
 
 [features]
-default = ["v3", "v4"]
+default = ["v4"]
 # V3 contains NIST approved algoritms only
 v3 = [
   "hmac",
@@ -39,13 +39,15 @@ v4 = [
   "rusty_paseto/v4_local",
   "rusty_paseto/v4_public"
 ]
+serde = ["dep:serde"]
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
-rusty_paseto = { version = "0.6.0", default-features = false, features = ["core"] }
+rusty_paseto = { version = "0.7.0", default-features = false, features = ["core"] }
 subtle = "2.5.0"
 generic-array = "0.14"
 base64ct = "1.6.0"
-base64 = "0.13.0"
+base64 = "0.22.1"
 cipher = "0.4.4"
 digest = { version = "0.10.7", features = ["mac"] }
 rand = "0.8.5"
@@ -75,7 +77,7 @@ serde = { version = "1", features = ["derive"] }
 hex = "0.4"
 ff = "0.13.0"
 
-libtest-mimic = "0.6.1"
+libtest-mimic = "0.7.3"
 
 [profile.dev.package."*"]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,23 @@ categories = [
 default = ["v4"]
 # V3 contains NIST approved algoritms only
 v3 = [
-  "hmac",
-  "aes",
-  "ctr",
-  "sha2",
-  "p384",
-  "pbkdf2",
+  "dep:hmac",
+  "dep:aes",
+  "dep:ctr",
+  "dep:sha2",
+  "dep:p384",
+  "dep:pbkdf2",
   "rusty_paseto/v3_local",
   "rusty_paseto/v3_public",
 ]
 # V4 is recommended
 v4 = [
-  "sha2",
-  "blake2",
-  "chacha20",
-  "ed25519-dalek",
-  "curve25519-dalek",
-  "argon2",
+  "dep:sha2",
+  "dep:blake2",
+  "dep:chacha20",
+  "dep:ed25519-dalek",
+  "dep:curve25519-dalek",
+  "dep:argon2",
   "rusty_paseto/v4_local",
   "rusty_paseto/v4_public"
 ]

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,6 +1,5 @@
 use std::{fmt, marker::PhantomData, str::FromStr};
 
-use base64::URL_SAFE_NO_PAD;
 use generic_array::{typenum::U33, GenericArray};
 
 use rusty_paseto::core::PasetoError;
@@ -62,13 +61,7 @@ impl<V: Version, K: KeyType<V>> FromStr for KeyId<V, K> {
             .ok_or(PasetoError::WrongHeader)?;
         let s = s.strip_prefix(K::ID).ok_or(PasetoError::WrongHeader)?;
 
-        let mut id = GenericArray::<u8, U33>::default();
-        let len = base64::decode_config_slice(s, URL_SAFE_NO_PAD, &mut id)?;
-        if len != 33 {
-            return Err(PasetoError::PayloadBase64Decode {
-                source: base64::DecodeError::InvalidLength,
-            });
-        }
+        let id = crate::read_b64(s)?;
 
         Ok(KeyId {
             id,

--- a/src/key/plaintext.rs
+++ b/src/key/plaintext.rs
@@ -1,8 +1,5 @@
 use std::{fmt, str::FromStr};
 
-use base64::URL_SAFE_NO_PAD;
-use cipher::Unsigned;
-use generic_array::GenericArray;
 use rusty_paseto::core::PasetoError;
 
 use crate::{write_b64, Key, KeyType, Version};
@@ -27,13 +24,7 @@ impl<V: Version, K: KeyType<V>> FromStr for PlaintextKey<V, K> {
             .ok_or(PasetoError::WrongHeader)?;
         let s = s.strip_prefix(K::HEADER).ok_or(PasetoError::WrongHeader)?;
 
-        let mut key = GenericArray::<u8, K::KeyLen>::default();
-        let len = base64::decode_config_slice(s, URL_SAFE_NO_PAD, &mut key)?;
-        if len != <K::KeyLen as Unsigned>::USIZE {
-            return Err(PasetoError::PayloadBase64Decode {
-                source: base64::DecodeError::InvalidLength,
-            });
-        }
+        let key = crate::read_b64(s)?;
 
         Ok(PlaintextKey(Key { key }))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ fn read_b64<L: GenericSequence<u8> + DerefMut<Target = [u8]> + Default>(
     let expected_len = (s.len() + 3) / 4 * 3;
     if expected_len < <L::Length as Unsigned>::USIZE {
         return Err(PasetoError::PayloadBase64Decode {
-            source: base64::DecodeError::InvalidLength,
+            source: base64::DecodeError::InvalidLength(s.len()),
         });
     }
 
@@ -220,13 +220,13 @@ fn read_b64<L: GenericSequence<u8> + DerefMut<Target = [u8]> + Default>(
 
     let len = base64ct::Base64UrlUnpadded::decode(s, &mut total)
         .map_err(|_| PasetoError::PayloadBase64Decode {
-            source: base64::DecodeError::InvalidLength,
+            source: base64::DecodeError::InvalidLength(s.len()),
         })?
         .len();
 
     if len != <L::Length as Unsigned>::USIZE {
         return Err(PasetoError::PayloadBase64Decode {
-            source: base64::DecodeError::InvalidLength,
+            source: base64::DecodeError::InvalidLength(s.len()),
         });
     }
 
@@ -289,7 +289,10 @@ pub mod fuzzing {
     impl<const N: usize> CryptoRng for FakeRng<N> {}
 
     pub mod seal {
-        pub use crate::pke::fuzz_tests::{V3SealInput, V4SealInput};
+        #[cfg(feature = "v3")]
+        pub use crate::pke::fuzz_tests::V3SealInput;
+        #[cfg(feature = "v4")]
+        pub use crate::pke::fuzz_tests::V4SealInput;
     }
     pub mod wrap {
         pub use crate::wrap::fuzz_tests::FuzzInput;

--- a/src/pke.rs
+++ b/src/pke.rs
@@ -438,18 +438,18 @@ impl<V: SealedVersion> fmt::Display for SealedKey<V> {
 
 #[cfg(any(test, fuzzing))]
 pub mod fuzz_tests {
-    use rusty_paseto::core::{V3, V4};
-
     use crate::{fuzzing::FakeRng, Key, Local, Secret};
 
+    #[cfg(feature = "v3")]
     #[derive(Debug)]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub struct V3SealInput {
-        key: Key<V3, Local>,
-        secret_key: Key<V3, Secret>,
+        key: Key<rusty_paseto::core::V3, Local>,
+        secret_key: Key<rusty_paseto::core::V3, Secret>,
         ephemeral: FakeRng<48>,
     }
 
+    #[cfg(feature = "v3")]
     impl V3SealInput {
         pub fn run(mut self) {
             let x: Option<p384::Scalar> =
@@ -469,14 +469,16 @@ pub mod fuzz_tests {
         }
     }
 
+    #[cfg(feature = "v4")]
     #[derive(Debug)]
     #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
     pub struct V4SealInput {
-        key: Key<V4, Local>,
-        secret_key: Key<V4, Secret>,
+        key: Key<rusty_paseto::core::V4, Local>,
+        secret_key: Key<rusty_paseto::core::V4, Secret>,
         ephemeral: FakeRng<32>,
     }
 
+    #[cfg(feature = "v4")]
     impl V4SealInput {
         pub fn run(mut self) {
             let sealed = self

--- a/tests/vectors.rs
+++ b/tests/vectors.rs
@@ -4,7 +4,7 @@ use libtest_mimic::{Arguments, Failed, Trial};
 use rusty_paserk::{
     internal::{PieVersion, PieWrapType, PwVersion, PwWrapType, SealedVersion},
     Key, KeyId, KeyType, Local, PasetoError, PieWrappedKey, PlaintextKey, Public, PwWrappedKey,
-    SealedKey, Secret, Version, V3, V4,
+    SealedKey, Secret, Version,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 
@@ -48,12 +48,20 @@ struct IdTest {
 
 impl IdTest {
     fn add_all_tests(tests: &mut Vec<Trial>) {
-        Self::add_tests::<V3, Local>(tests);
-        Self::add_tests::<V4, Local>(tests);
-        Self::add_tests::<V3, Secret>(tests);
-        Self::add_tests::<V4, Secret>(tests);
-        Self::add_tests::<V3, Public>(tests);
-        Self::add_tests::<V4, Public>(tests);
+        #[cfg(feature = "v3")]
+        {
+            use rusty_paserk::V3;
+            Self::add_tests::<V3, Local>(tests);
+            Self::add_tests::<V3, Secret>(tests);
+            Self::add_tests::<V3, Public>(tests);
+        }
+        #[cfg(feature = "v4")]
+        {
+            use rusty_paserk::V4;
+            Self::add_tests::<V4, Local>(tests);
+            Self::add_tests::<V4, Secret>(tests);
+            Self::add_tests::<V4, Public>(tests);
+        }
     }
 
     fn add_tests<V: Version, K: KeyType<V>>(tests: &mut Vec<Trial>)
@@ -97,12 +105,20 @@ struct KeyTest {
 
 impl KeyTest {
     fn add_all_tests(tests: &mut Vec<Trial>) {
-        Self::add_tests::<V3, Local>(tests);
-        Self::add_tests::<V4, Local>(tests);
-        Self::add_tests::<V3, Secret>(tests);
-        Self::add_tests::<V4, Secret>(tests);
-        Self::add_tests::<V3, Public>(tests);
-        Self::add_tests::<V4, Public>(tests);
+        #[cfg(feature = "v3")]
+        {
+            use rusty_paserk::V3;
+            Self::add_tests::<V3, Local>(tests);
+            Self::add_tests::<V3, Secret>(tests);
+            Self::add_tests::<V3, Public>(tests);
+        }
+        #[cfg(feature = "v4")]
+        {
+            use rusty_paserk::V4;
+            Self::add_tests::<V4, Local>(tests);
+            Self::add_tests::<V4, Secret>(tests);
+            Self::add_tests::<V4, Public>(tests);
+        }
     }
 
     fn add_tests<V: Version, K: KeyType<V>>(tests: &mut Vec<Trial>)
@@ -155,10 +171,18 @@ struct PbkwTest {
 
 impl PbkwTest {
     fn add_all_tests(tests: &mut Vec<Trial>) {
-        Self::add_tests::<V3, Local>(tests);
-        Self::add_tests::<V4, Local>(tests);
-        Self::add_tests::<V3, Secret>(tests);
-        Self::add_tests::<V4, Secret>(tests);
+        #[cfg(feature = "v3")]
+        {
+            use rusty_paserk::V3;
+            Self::add_tests::<V3, Local>(tests);
+            Self::add_tests::<V3, Secret>(tests);
+        }
+        #[cfg(feature = "v4")]
+        {
+            use rusty_paserk::V4;
+            Self::add_tests::<V4, Local>(tests);
+            Self::add_tests::<V4, Secret>(tests);
+        }
     }
 
     fn add_tests<V: PwVersion, K: PwWrapType<V>>(tests: &mut Vec<Trial>) {
@@ -206,8 +230,10 @@ struct PkeTest {
 
 impl PkeTest {
     fn add_all_tests(tests: &mut Vec<Trial>) {
-        Self::add_tests::<V3>(tests);
-        Self::add_tests::<V4>(tests);
+        #[cfg(feature = "v3")]
+        Self::add_tests::<rusty_paserk::V3>(tests);
+        #[cfg(feature = "v4")]
+        Self::add_tests::<rusty_paserk::V4>(tests);
     }
 
     fn add_tests<V: SealedVersion>(tests: &mut Vec<Trial>)
@@ -261,10 +287,18 @@ struct PieWrapTest {
 
 impl PieWrapTest {
     fn add_all_tests(tests: &mut Vec<Trial>) {
-        Self::add_tests::<V3, Local>(tests);
-        Self::add_tests::<V4, Local>(tests);
-        Self::add_tests::<V3, Secret>(tests);
-        Self::add_tests::<V4, Secret>(tests);
+        #[cfg(feature = "v3")]
+        {
+            use rusty_paserk::V3;
+            Self::add_tests::<V3, Local>(tests);
+            Self::add_tests::<V3, Secret>(tests);
+        }
+        #[cfg(feature = "v4")]
+        {
+            use rusty_paserk::V4;
+            Self::add_tests::<V4, Local>(tests);
+            Self::add_tests::<V4, Secret>(tests);
+        }
     }
 
     fn add_tests<V: PieVersion, K: PieWrapType<V>>(tests: &mut Vec<Trial>)
@@ -311,61 +345,72 @@ trait NewKey {
     fn from_key(s: &str) -> Self;
 }
 
-impl NewKey for Key<V3, Local> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_bytes(b.try_into().unwrap())
-    }
-}
-
-impl NewKey for Key<V4, Local> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_bytes(b.try_into().unwrap())
-    }
-}
-
-impl NewKey for Key<V3, Secret> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_bytes(&b).unwrap()
-    }
-}
-
-impl NewKey for Key<V4, Secret> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_keypair_bytes(&b).unwrap()
-    }
-}
-
-impl NewKey for Key<V3, Public> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_sec1_bytes(&b).unwrap()
-    }
-}
-
-impl NewKey for Key<V4, Public> {
-    fn from_key(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_public_key(&b).unwrap()
-    }
-}
-
 trait NewKey2 {
     fn from_key2(s: &str) -> Self;
 }
 
-impl NewKey2 for Key<V3, Secret> {
-    fn from_key2(s: &str) -> Self {
-        Self::from_sec1_pem(s).unwrap()
+#[cfg(feature = "v3")]
+mod v3_impls {
+    use super::*;
+    use rusty_paserk::V3;
+
+    impl NewKey for Key<V3, Local> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_bytes(b.try_into().unwrap())
+        }
+    }
+
+    impl NewKey for Key<V3, Secret> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_bytes(&b).unwrap()
+        }
+    }
+
+    impl NewKey for Key<V3, Public> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_sec1_bytes(&b).unwrap()
+        }
+    }
+
+    impl NewKey2 for Key<V3, Secret> {
+        fn from_key2(s: &str) -> Self {
+            Self::from_sec1_pem(s).unwrap()
+        }
     }
 }
 
-impl NewKey2 for Key<V4, Secret> {
-    fn from_key2(s: &str) -> Self {
-        let b = hex::decode(s).unwrap();
-        Self::from_keypair_bytes(&b).unwrap()
+#[cfg(feature = "v4")]
+mod v4_impls {
+    use super::*;
+    use rusty_paserk::V4;
+
+    impl NewKey for Key<V4, Local> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_bytes(b.try_into().unwrap())
+        }
+    }
+    impl NewKey for Key<V4, Secret> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_keypair_bytes(&b).unwrap()
+        }
+    }
+
+    impl NewKey for Key<V4, Public> {
+        fn from_key(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_public_key(&b).unwrap()
+        }
+    }
+
+    impl NewKey2 for Key<V4, Secret> {
+        fn from_key2(s: &str) -> Self {
+            let b = hex::decode(s).unwrap();
+            Self::from_keypair_bytes(&b).unwrap()
+        }
     }
 }


### PR DESCRIPTION
Updates rusty_paseto to 0.7.

This compile error has force me to move away from having both v3 and v4 features enabled by default. https://github.com/rrrodzilla/rusty_paseto/issues/36#issuecomment-2136664371. This has forced a lot of tests to be slightly tweaked but should still work